### PR TITLE
fix: press Cancel it's not properly refreshing the unit

### DIFF
--- a/src/course-unit/add-component/AddComponent.jsx
+++ b/src/course-unit/add-component/AddComponent.jsx
@@ -1,13 +1,13 @@
 import { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { getConfig } from '@edx/frontend-platform';
 import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 import {
   ActionRow, Button, StandardModal, useToggle,
 } from '@openedx/paragon';
 
-import { getCourseSectionVertical } from '../data/selectors';
+import { getCourseSectionVertical, getCourseUnitData } from '../data/selectors';
 import { getWaffleFlags } from '../../data/selectors';
 import { COMPONENT_TYPES } from '../../generic/block-type-utils/constants';
 import ComponentModalView from './add-component-modals/ComponentModalView';
@@ -19,6 +19,7 @@ import { useIframe } from '../../generic/hooks/context/hooks';
 import { useEventListener } from '../../generic/hooks';
 import VideoSelectorPage from '../../editors/VideoSelectorPage';
 import EditorPage from '../../editors/EditorPage';
+import { fetchCourseSectionVerticalData } from '../data/thunk';
 
 const AddComponent = ({
   parentLocator,
@@ -28,6 +29,8 @@ const AddComponent = ({
   handleCreateNewCourseXBlock,
 }) => {
   const intl = useIntl();
+  const dispatch = useDispatch();
+
   const [isOpenAdvanced, openAdvanced, closeAdvanced] = useToggle(false);
   const [isOpenHtml, openHtml, closeHtml] = useToggle(false);
   const [isOpenOpenAssessment, openOpenAssessment, closeOpenAssessment] = useToggle(false);
@@ -45,6 +48,9 @@ const AddComponent = ({
   const [usageId, setUsageId] = useState(null);
   const { sendMessageToIframe } = useIframe();
   const { useVideoGalleryFlow, useReactMarkdownEditor } = useSelector(getWaffleFlags);
+
+  const courseUnit = useSelector(getCourseUnitData);
+  const sequenceId = courseUnit?.ancestorInfo?.ancestors?.[0]?.id;
 
   const receiveMessage = useCallback(({ data: { type, payload } }) => {
     if (type === messageTypes.showMultipleComponentPicker) {
@@ -67,7 +73,15 @@ const AddComponent = ({
     closeXBlockEditorModal();
     closeVideoSelectorModal();
     sendMessageToIframe(messageTypes.refreshXBlock, null);
+    dispatch(fetchCourseSectionVerticalData(blockId, sequenceId));
   }, [closeXBlockEditorModal, closeVideoSelectorModal, sendMessageToIframe]);
+
+  const onXBlockCancel = useCallback(/* istanbul ignore next */ () => {
+    // ignoring tests because it triggers when someone closes the editor which has a separate store
+    closeXBlockEditorModal();
+    closeVideoSelectorModal();
+    dispatch(fetchCourseSectionVerticalData(blockId, sequenceId));
+  }, [closeXBlockEditorModal, closeVideoSelectorModal, sendMessageToIframe, blockId, sequenceId]);
 
   const handleLibraryV2Selection = useCallback((selection) => {
     handleCreateNewCourseXBlock({
@@ -261,7 +275,7 @@ const AddComponent = ({
               isMarkdownEditorEnabledForCourse={useReactMarkdownEditor}
               studioEndpointUrl={getConfig().STUDIO_BASE_URL}
               lmsEndpointUrl={getConfig().LMS_BASE_URL}
-              onClose={closeXBlockEditorModal}
+              onClose={onXBlockCancel}
               returnFunction={/* istanbul ignore next */ () => onXBlockSave}
             />
           </div>


### PR DESCRIPTION
## Description

Fixes a Studio bug where empty/blank components appeared in a unit after a user clicked an "Add Component" button (Text, Problem, Video, etc.), opened the editor, and then discarded without saving. The empty XBlock is created on the server the moment the button is clicked (so the editor has a real block ID), but previously the UI did not refresh on cancel, so the blank component only surfaced later — usually after saving a different component — making it look like saving caused the extra empty block.

After this change, cancelling the editor triggers a fresh fetch of the unit, so any block created by the click is visible immediately. Backport of upstream openedx/frontend-app-authoring commit `f9cd15ee`.

> Note: as with upstream, the empty block is still persisted on the server — the user now simply sees it right away and can delete it manually.

## Youtrack

- https://youtrack.raccoongang.com/issue/TEA-162

## Supporting information

Issue: https://github.com/openedx/frontend-app-authoring/issues/2261

## After Fix

#### Upstream demo
https://github.com/user-attachments/assets/702c99ed-6584-4951-908b-1a58ba4b140f

#### RG demo
https://github.com/user-attachments/assets/52bc2dd1-82ac-4a5a-a110-2f0f7f90af9f 

## Testing

1. **Happy path — cancel text component**
   - Preconditions: logged in as a staff user in Studio; on a course with at least one section/subsection.
   - Steps: open any unit → click **Text** → wait for the editor modal → click **Cancel** without typing anything.
   - Expected: the unit refreshes and a blank Text component is visible in the unit immediately. No other changes.

2. **Cancel then add — the bug's original STR**
   - Preconditions: same as above, inside any unit.
   - Steps: click **Text** → cancel the editor → click **Text** again → type some content → **Save**.
   - Expected: both the previously-cancelled blank component and the new saved component are visible (the blank one was created when the first button was clicked; now it just shows up immediately instead of silently reappearing after save). The user can delete the blank one manually.

3. **Problem component**
   - Steps: in any unit, click **Problem** → pick any template → when the editor opens, click **Cancel**.
   - Expected: the unit refreshes; a blank Problem component is visible.

4. **Video component**
   - Steps: in any unit, click **Video** → when the editor/video selector opens, close it without saving.
   - Expected: the unit refreshes; a blank Video component is visible.

5. **Save path regression check**
   - Steps: in any unit, click **Text** → type content → **Save**.
   - Expected: the saved component appears once in the unit with the typed content. No duplicates, no blank companions. Existing save behavior is unchanged.

6. **Components that don't open an editor (regression check)**
   - Steps: click **Discussion** (or Drag-and-drop) in a unit.
   - Expected: the component is added as before. No change in behavior.
