### PR TITLE
feat: [ENG-63] dark theme for TinyMCE editor surface

### DIFF
--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -9,6 +9,9 @@ and this project adheres to customized Semantic Versioning e.g.: `teak-rg.1`
 [Unreleased]
 ************
 
+Added:
+======
+* Apply dark-theme content styles to the TinyMCE editing surface when the shared ``theme-variant`` cookie is ``dark`` (ENG-63)
 
 [release/teak-rg.4] - 2026-02-27
 ================================

--- a/src/editors/sharedComponents/TinyMceWidget/hooks.js
+++ b/src/editors/sharedComponents/TinyMceWidget/hooks.js
@@ -20,6 +20,41 @@ import * as tinyMCE from '../../data/constants/tinyMCE';
 import { getRelativeUrl, getStaticUrl, parseAssetName } from './utils';
 import { isLibraryKey } from '../../../generic/key-utils';
 
+/**
+ * Dark-theme content styles for the TinyMCE editing surface.
+ *
+ * The editor renders inside its own same-origin <iframe>, so the Paragon dark
+ * variant / theme CSS cannot reach it — its only styling is `content_style`
+ * (see `tinyMCEStyles`, which hard-codes a white "paper" body with #3c3c3c
+ * text). In dark mode that paper is a glaring white block on the dark page.
+ *
+ * We append a dark override (so it wins by source order) when the shared
+ * `theme-variant` cookie is `dark`. Evaluated each time the editor mounts, so a
+ * reload after toggling picks up the change. Mirrors the LMS dark surface
+ * (#1b1b1b) so authors see content close to how learners see it in dark mode.
+ */
+export const darkContentStyle = () => {
+  if (typeof document === 'undefined'
+    || !/(?:^|;\s*)theme-variant=dark/.test(document.cookie)) {
+    return '';
+  }
+  return `
+    .mce-content-body { background-color: #1b1b1b; color: #e8e8e8; }
+    .mce-content-body h1, .mce-content-body .hd-1,
+    .mce-content-body h3, .mce-content-body .hd-3,
+    .mce-content-body h4, .mce-content-body .hd-4,
+    .mce-content-body h5, .mce-content-body .hd-5,
+    .mce-content-body h6, .mce-content-body .hd-6,
+    .mce-content-body p, .mce-content-body li,
+    .mce-content-body ol, .mce-content-body ul,
+    .mce-content-body pre, .mce-content-body code { color: #e8e8e8; }
+    .mce-content-body h2, .mce-content-body .hd-2 { color: #c9c9c9; }
+    .mce-content-body a, .mce-content-body a:link, .mce-content-body a:visited,
+    .mce-content-body a:hover, .mce-content-body a:active { color: #5badec; }
+    .mce-content-body[data-mce-placeholder]:not(.mce-visualblocks)::before { color: #adadad; }
+  `;
+};
+
 export const state = StrictDict({
   // eslint-disable-next-line react-hooks/rules-of-hooks
   isImageModalOpen: (val) => useState(val),
@@ -334,7 +369,7 @@ export const editorConfig = ({
       ...config,
       skin: false,
       content_css: false,
-      content_style: tinyMCEStyles + a11ycheckerCss,
+      content_style: tinyMCEStyles + a11ycheckerCss + module.darkContentStyle(),
       min_height: minHeight,
       max_height: maxHeight,
       contextmenu: 'link table',


### PR DESCRIPTION
## Description

When a course author turns on dark mode, the rich-text (TinyMCE) editor used
for HTML and Problem components still showed its content on a bright white
"paper" surface — a glaring white block in an otherwise dark UI. This change
makes the editor's content area follow the dark theme, with a dark background,
light text, and readable link colors, so authoring content feels consistent
with the rest of dark mode and closely matches how learners see that content
in the dark LMS.

## Youtrack

- https://youtrack.raccoongang.com/issue/ENG-63

## Screenshot/Video

| 1 | 2 | 3 |
|--------|--------|--------|
| <img width="3456" height="5359" alt="image" src="https://github.com/user-attachments/assets/97ed66a8-3756-4dd8-8ebc-f21ac79a0220" /> | <img width="3456" height="11168" alt="image" src="https://github.com/user-attachments/assets/1fb6d489-1db2-4378-ad13-e04451d827e5" /> | <img width="1920" height="5755" alt="image" src="https://github.com/user-attachments/assets/64debc05-a525-43ea-91a1-767c0a82e7ed" /> | 

## Testing

**1. Dark editing surface (happy path)**
1. As a course author/staff member with dark mode enabled (the
   `theme-variant=dark` cookie is set), open Studio (authoring MFE).
2. Open a Text/HTML component — or a Problem component — to launch the TinyMCE
   editor.
3. Expected: the editor's content area renders dark (dark background, light
   body text, blue links, legible headings/lists/code), not a white block.

**2. Light mode unchanged**
1. With dark mode off (no `theme-variant` cookie, or set to `light`), open the
   same editor.
2. Expected: the editor shows its original white surface with dark text —
   no visual change from before.

**3. Toggle then reload**
1. Open the editor in light mode.
2. Switch to dark mode, then reload the page and reopen the editor.
3. Expected: the editor surface is now dark. (Styles are evaluated when the
   editor mounts, so a reload after toggling is expected to apply them.)

**4. Element readability in dark**
1. In a dark-mode editor, add headings (h1–h6), bulleted/numbered lists, a
   code/preformatted block, links, and leave a field empty to show its
   placeholder.
2. Expected: every element is clearly legible against the dark surface; the
   placeholder text is dimmed but readable.
